### PR TITLE
fix(package.json): fixes lint script commands for windows os

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "React Redux Typescript boilerplate",
     "main": "index.js",
     "scripts": {
-        "lint:css": "stylelint 'src/**/*.tsx'",
-        "lint:ts": "eslint 'src/**/*.{ts,tsx}'",
+        "lint:css": "stylelint src/**/*.tsx",
+        "lint:ts": "eslint src/**/*.{ts,tsx}",
         "test:update": "run-p type-check 'test:jest -- -u'",
         "test:watch": "run-p 'type-check -- -w' 'test:jest -- --watch'",
         "test:jest": "jest --config config/jest/jest.config.js",


### PR DESCRIPTION
`yarn lint` command was failing on Windows.

![image (1)](https://user-images.githubusercontent.com/8468992/117097743-1e471880-ad8a-11eb-9f16-88b4f1f8cbed.png)

This PR fixes the error for both Windows and Mac OS.